### PR TITLE
Modifications of view.sica 

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,24 @@ animator.removeAll()
     public func removeAll() -> Self
 ```
 
+## Extensions
+
+You can access sica property in `UIView` and `CALayer`.
+
+```swift
+let view = UIView(frame: ...)
+view.sica
+    .addBasicAnimation(keyPath: .positionX, from: 50, to: 150, duration: 2, timingFunction: .easeOutExpo)
+    .run(type: .sequence)
+```
+
+```swift
+let layer = CALayer()
+layer.sica
+    .addBasicAnimation(keyPath: .positionX, from: 50, to: 150, duration: 2, timingFunction: .easeOutExpo)
+    .run(type: .sequence)
+```
+
 ## Support
 
 ### Animation

--- a/Sica.xcodeproj/project.pbxproj
+++ b/Sica.xcodeproj/project.pbxproj
@@ -23,6 +23,10 @@
 		9D436C5A20E9E8F200A1B938 /* Sica.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D4A60FE320ABC9890079871A /* Sica.framework */; };
 		9D436C6620E9EA1E00A1B938 /* SicaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4A60FF120ABC9890079871A /* SicaTests.swift */; };
 		9D436C6820E9EA1E00A1B938 /* Sica.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D4A60FE320ABC9890079871A /* Sica.framework */; };
+		9D68159620EF10BB007B3FB0 /* CALayer+Sica.swift in Sources */ = {isa = PBXBuildFile; fileRef = D449535220EE1F20004C8AB9 /* CALayer+Sica.swift */; };
+		9D68159720EF10BC007B3FB0 /* CALayer+Sica.swift in Sources */ = {isa = PBXBuildFile; fileRef = D449535220EE1F20004C8AB9 /* CALayer+Sica.swift */; };
+		9D68159820EF10BF007B3FB0 /* View+Sica.swift in Sources */ = {isa = PBXBuildFile; fileRef = D449535020EE1BAF004C8AB9 /* View+Sica.swift */; };
+		9D68159920EF10BF007B3FB0 /* View+Sica.swift in Sources */ = {isa = PBXBuildFile; fileRef = D449535020EE1BAF004C8AB9 /* View+Sica.swift */; };
 		D449535120EE1BAF004C8AB9 /* View+Sica.swift in Sources */ = {isa = PBXBuildFile; fileRef = D449535020EE1BAF004C8AB9 /* View+Sica.swift */; };
 		D449535320EE1F20004C8AB9 /* CALayer+Sica.swift in Sources */ = {isa = PBXBuildFile; fileRef = D449535220EE1F20004C8AB9 /* CALayer+Sica.swift */; };
 		D4A60FED20ABC9890079871A /* Sica.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D4A60FE320ABC9890079871A /* Sica.framework */; };
@@ -477,7 +481,9 @@
 				9D436C3320E9E4DD00A1B938 /* Transition.swift in Sources */,
 				9D436C3420E9E4DD00A1B938 /* CAAnimation+Extension.swift in Sources */,
 				9D436C3520E9E4DD00A1B938 /* Animator.swift in Sources */,
+				9D68159820EF10BF007B3FB0 /* View+Sica.swift in Sources */,
 				9D436C3620E9E4DD00A1B938 /* AnimationKeyPaths.swift in Sources */,
+				9D68159620EF10BB007B3FB0 /* CALayer+Sica.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -489,7 +495,9 @@
 				9D436C4520E9E71900A1B938 /* Transition.swift in Sources */,
 				9D436C4620E9E71900A1B938 /* CAAnimation+Extension.swift in Sources */,
 				9D436C4720E9E71900A1B938 /* Animator.swift in Sources */,
+				9D68159920EF10BF007B3FB0 /* View+Sica.swift in Sources */,
 				9D436C4820E9E71900A1B938 /* AnimationKeyPaths.swift in Sources */,
+				9D68159720EF10BC007B3FB0 /* CALayer+Sica.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sica/Source/Animator.swift
+++ b/Sica/Source/Animator.swift
@@ -31,6 +31,13 @@ public final class Animator {
 
     public let key: String
 
+    #if DEBUG
+    private var _deinit: (() -> ())? = nil
+    deinit {
+        _deinit?()
+    }
+    #endif
+
     public init(view: View, forKey key: String? = nil) {
         #if os(iOS) || os(tvOS)
         self.layer = view.layer
@@ -167,6 +174,10 @@ extension Animator {
         }
         var animations: [CAAnimation] {
             return base.animations
+        }
+
+        func setDeinit(_ _deinit: (() -> ())?) {
+            base._deinit = _deinit
         }
     }
 

--- a/Sica/Source/Animator.swift
+++ b/Sica/Source/Animator.swift
@@ -24,7 +24,7 @@ public final class Animator {
         case parallel
     }
 
-    private let layer: CALayer
+    private weak var layer: CALayer?
     private var group = CAAnimationGroup()
     private var animations = [CAAnimation]()
     public private(set) var isCompleted: Bool = false
@@ -89,7 +89,7 @@ public final class Animator {
     }
 
     public func removeAll() -> Self {
-        layer.removeAllAnimations()
+        layer?.removeAllAnimations()
         group = CAAnimationGroup()
         animations = []
         isCompleted = false
@@ -97,7 +97,7 @@ public final class Animator {
     }
 
     public func cancel() {
-        layer.removeAnimation(forKey: key)
+        layer?.removeAnimation(forKey: key)
     }
 
     public func run(type: AnimationPlayType, isRemovedOnCompletion: Bool = false, completion: (() -> Void)? = nil) {
@@ -115,10 +115,10 @@ public final class Animator {
             CATransaction.setCompletionBlock {
                 completion()
             }
-            layer.add(group, forKey: key)
+            layer?.add(group, forKey: key)
             CATransaction.commit()
         } else {
-            layer.add(group, forKey: key)
+            layer?.add(group, forKey: key)
         }
         isCompleted = true
     }

--- a/SicaTests/SicaTests.swift
+++ b/SicaTests/SicaTests.swift
@@ -140,4 +140,36 @@ class SicaTests: XCTestCase {
         XCTAssertEqual(animator.test.animations.count, 0)
         XCTAssertEqual(animator.isCompleted, false)
     }
+
+    func testSicaPropertyOfView() {
+        var view: View! = View(frame: .zero)
+
+        XCTAssertNotNil(view.sica)
+
+        let expect = expectation(description: "wait deinit call of sica instance")
+
+        view.sica.test.setDeinit {
+            expect.fulfill()
+        }
+
+        view = nil
+
+        wait(for: [expect], timeout: 0.1)
+    }
+
+    func testSicaPropertyOfLayer() {
+        var layer: CALayer! = CALayer()
+
+        XCTAssertNotNil(layer.sica)
+
+        let expect = expectation(description: "wait deinit call of sica instance")
+
+        layer.sica.test.setDeinit {
+            expect.fulfill()
+        }
+
+        layer = nil
+
+        wait(for: [expect], timeout: 0.1)
+    }
 }


### PR DESCRIPTION
There are 4 modifications in this PR.

- 544bb451de4d6501189c2be339df7ff9e15e3a9e add deinit test

- 971f3308cdb0617ecb522bbdbfbc8742cd2f3fa2 fix reference cycle

layer.sica caused reference cycle because sica instance has strong reference of layer instance.

- aecba50a6ffc2b8c20a8407758611976c11d328e fix target membership

`CALayer+Sica.swift` and `View+Sica.swift` were not contained tvOS and macOS target membership.
Therefore, `view.sica` and `layer.sica` were not accessible in tvOS and macOS. 

- 8c29d55fd73db4a6c5687271dacff25da232706e update README