### PR TITLE
Swift PM v5.1

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,9 +1,13 @@
-// swift-tools-version:4.0
-// The swift-tools-version declares the minimum version of Swift required to build this package.
+// swift-tools-version:5.1
 
 import PackageDescription
 let package = Package(
     name: "Sica",
+    platforms: [
+        .iOS(.v9),
+        .macOS(.v10_10),
+        .tvOS(.v10)
+    ],
     products: [
         .library(
             name: "Sica",
@@ -14,5 +18,6 @@ let package = Package(
             name: "Sica",
             dependencies: [],
             path: "Sica/Source")
-    ]
+    ],
+    swiftLanguageVersions: [ .v5 ]
 )

--- a/Sica.podspec
+++ b/Sica.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name         = "Sica"
-  s.version      = "0.4.0"
+  s.version      = "0.4.1"
   s.summary      = "Sica can execute various animations sequentially or parallely"
   s.homepage     = "https://github.com/cats-oss/Sica"
   s.license      = { :type => "MIT", :file => "LICENSE" }
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target  = "9.0"
   s.tvos.deployment_target = "10.0"
   s.osx.deployment_target  = "10.11"
-  s.source       = { :git => "https://github.com/cats-oss/Sica.git", :tag => "#{s.version}" }
+  s.source       = { :git => "https://github.com/cats-oss/Sica.git", :tag => "v#{s.version}" }
   s.source_files = "Sica/**/*.{swift}"
   s.swift_version = '5.0'
 end

--- a/Sica/Source/CALayer+Sica.swift
+++ b/Sica/Source/CALayer+Sica.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import QuartzCore
 
 private let _animatorAssociatedKey = UnsafeMutablePointer<UInt>.allocate(capacity: 1)
 

--- a/Sica/Source/FillMode.swift
+++ b/Sica/Source/FillMode.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import QuartzCore
 
 public struct FillMode {
     #if swift(>=4.2)


### PR DESCRIPTION
In order to be used by Xcode11's Package manager.

Sidenote: For future releases tag them with "v" (e.g. `v0.4.1`)