### PR TITLE
Add flag whether or not to include the delay in the duration calculation when parallel

### DIFF
--- a/Sica/Source/Animator.swift
+++ b/Sica/Source/Animator.swift
@@ -24,6 +24,9 @@ public final class Animator {
         case parallel
     }
 
+    /// Flag whether or not to include the delay in the duration calculation when parallel.
+    public static var shouldIncludeDelayInParallelDuration: Bool = false
+
     private weak var layer: CALayer?
     private var group = CAAnimationGroup()
     private var animations = [CAAnimation]()
@@ -70,7 +73,11 @@ public final class Animator {
         case .sequence:
             return animations.last.map { $0.beginTime + $0.duration } ?? 0
         case .parallel:
-            return animations.map { $0.duration }.max() ?? 0
+            if Self.shouldIncludeDelayInParallelDuration {
+                return animations.map { $0.beginTime + $0.duration }.max() ?? 0
+            } else {
+                return animations.map { $0.duration }.max() ?? 0
+            }
         }
     }
 


### PR DESCRIPTION
When `.run(type: .parallel)` is executed after setting `delay` greater than 0 for `add**Animation`, the animation terminates in the middle.
I guessed that this is because the `beginTime` (=delay) is not included in the calculation of `totalDuration` when running in parallel.

However, this fix may have unexpected effects on other developers, so I added a static flag to change the behavior as an option.