### PR TITLE
Swift6対応

### DIFF
--- a/Sica.xcodeproj/project.pbxproj
+++ b/Sica.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -355,8 +355,9 @@
 		D4A60FDA20ABC9890079871A /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				BuildIndependentTargetsInParallel = YES;
 				LastSwiftUpdateCheck = 0930;
-				LastUpgradeCheck = 0930;
+				LastUpgradeCheck = 1640;
 				ORGANIZATIONNAME = "中澤 郁斗";
 				TargetAttributes = {
 					D4A60FE220ABC9890079871A = {
@@ -573,11 +574,13 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Manual;
+				DEAD_CODE_STRIPPING = YES;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = YES;
 				INFOPLIST_FILE = "$(SRCROOT)/Sica/Resource/Info-macOS.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -585,7 +588,8 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu11 gnu++14";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cats-oss.sica";
 				PRODUCT_NAME = Sica;
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -601,11 +605,13 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Manual;
+				DEAD_CODE_STRIPPING = YES;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = YES;
 				INFOPLIST_FILE = "$(SRCROOT)/Sica/Resource/Info-macOS.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -613,7 +619,8 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MACOSX_DEPLOYMENT_TARGET = 11.0;
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu11 gnu++14";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cats-oss.sica";
 				PRODUCT_NAME = Sica;
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -634,6 +641,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = YES;
 				INFOPLIST_FILE = "$(SRCROOT)/Sica/Resource/Info-tvOS.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -641,6 +649,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu11 gnu++14";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cats-oss.sica";
 				PRODUCT_NAME = Sica;
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -648,7 +657,7 @@
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 3;
-				TVOS_DEPLOYMENT_TARGET = 10.0;
+				TVOS_DEPLOYMENT_TARGET = 12.0;
 			};
 			name = Debug;
 		};
@@ -662,6 +671,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = YES;
 				INFOPLIST_FILE = "$(SRCROOT)/Sica/Resource/Info-tvOS.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -669,6 +679,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu11 gnu++14";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cats-oss.sica";
 				PRODUCT_NAME = Sica;
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -676,14 +687,13 @@
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 3;
-				TVOS_DEPLOYMENT_TARGET = 10.0;
+				TVOS_DEPLOYMENT_TARGET = 12.0;
 			};
 			name = Release;
 		};
 		9D436C5D20E9E8F200A1B938 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = "";
@@ -705,7 +715,6 @@
 		9D436C5E20E9E8F200A1B938 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = "";
@@ -727,9 +736,9 @@
 		9D436C6B20E9EA1E00A1B938 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_IDENTITY = "Mac Developer";
 				CODE_SIGN_STYLE = Manual;
+				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "SicaTests/Info-macOS.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -749,9 +758,9 @@
 		9D436C6C20E9EA1E00A1B938 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_IDENTITY = "Mac Developer";
 				CODE_SIGN_STYLE = Manual;
+				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "SicaTests/Info-macOS.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -794,6 +803,7 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
@@ -806,6 +816,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -857,6 +868,7 @@
 				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
 				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
 				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
 				CLANG_WARN_STRICT_PROTOTYPES = YES;
 				CLANG_WARN_SUSPICIOUS_MOVE = YES;
@@ -869,6 +881,7 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -898,6 +911,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = YES;
 				INFOPLIST_FILE = "$(SRCROOT)/Sica/Resource/Info-iOS.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -905,6 +919,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu11 gnu++14";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cats-oss.sica";
 				PRODUCT_NAME = Sica;
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -924,6 +939,7 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_MODULE_VERIFIER = YES;
 				INFOPLIST_FILE = "$(SRCROOT)/Sica/Resource/Info-iOS.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -931,6 +947,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
+				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu11 gnu++14";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cats-oss.sica";
 				PRODUCT_NAME = Sica;
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -943,7 +960,6 @@
 		D4A60FFB20ABC9890079871A /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = "";
@@ -964,7 +980,6 @@
 		D4A60FFC20ABC9890079871A /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = "";

--- a/Sica.xcodeproj/project.pbxproj
+++ b/Sica.xcodeproj/project.pbxproj
@@ -580,7 +580,6 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "$(SRCROOT)/Sica/Resource/Info-macOS.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -609,7 +608,6 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "$(SRCROOT)/Sica/Resource/Info-macOS.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -638,7 +636,6 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "$(SRCROOT)/Sica/Resource/Info-tvOS.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -667,7 +664,6 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "$(SRCROOT)/Sica/Resource/Info-tvOS.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -824,7 +820,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.6;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -881,7 +877,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 11.3;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.6;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
@@ -904,7 +900,6 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "$(SRCROOT)/Sica/Resource/Info-iOS.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -931,7 +926,6 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "$(SRCROOT)/Sica/Resource/Info-iOS.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Sica.xcodeproj/project.pbxproj
+++ b/Sica.xcodeproj/project.pbxproj
@@ -550,7 +550,6 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -581,7 +580,6 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = macosx;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -610,7 +608,6 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 12.0;
 			};
@@ -640,7 +637,6 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 12.0;
 			};
@@ -662,7 +658,6 @@
 				PRODUCT_NAME = SicaTests;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = appletvos;
-				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 3;
 			};
 			name = Debug;
@@ -683,7 +678,6 @@
 				PRODUCT_NAME = SicaTests;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = appletvos;
-				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 3;
 			};
 			name = Release;
@@ -705,7 +699,6 @@
 				PRODUCT_NAME = SicaTests;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = macosx;
-				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -727,7 +720,6 @@
 				PRODUCT_NAME = SicaTests;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = macosx;
-				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -792,6 +784,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 6.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -850,6 +843,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				SWIFT_VERSION = 6.0;
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -879,7 +873,6 @@
 				PRODUCT_NAME = Sica;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -907,7 +900,6 @@
 				PRODUCT_NAME = Sica;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -927,7 +919,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cats-oss.SicaTests";
 				PRODUCT_NAME = SicaTests;
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -947,7 +938,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.cats-oss.SicaTests";
 				PRODUCT_NAME = SicaTests;
 				PROVISIONING_PROFILE_SPECIFIER = "";
-				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/Sica.xcodeproj/project.pbxproj
+++ b/Sica.xcodeproj/project.pbxproj
@@ -246,7 +246,6 @@
 				9D436C3720E9E4DD00A1B938 /* Frameworks */,
 				9D436C3820E9E4DD00A1B938 /* Headers */,
 				9D436C3A20E9E4DD00A1B938 /* Resources */,
-				9D436C3B20E9E4DD00A1B938 /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -265,7 +264,6 @@
 				9D436C4920E9E71900A1B938 /* Frameworks */,
 				9D436C4A20E9E71900A1B938 /* Headers */,
 				9D436C4C20E9E71900A1B938 /* Resources */,
-				9D436C4D20E9E71900A1B938 /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -320,7 +318,6 @@
 				D4A60FDF20ABC9890079871A /* Frameworks */,
 				D4A60FE020ABC9890079871A /* Headers */,
 				D4A60FE120ABC9890079871A /* Resources */,
-				D42CFBF020BE4A4700A1A812 /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -435,48 +432,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
-
-/* Begin PBXShellScriptBuildPhase section */
-		9D436C3B20E9E4DD00A1B938 /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "";
-		};
-		9D436C4D20E9E71900A1B938 /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "";
-		};
-		D42CFBF020BE4A4700A1A812 /* ShellScript */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "";
-		};
-/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		9D436C3120E9E4DD00A1B938 /* Sources */ = {

--- a/Sica.xcodeproj/xcshareddata/xcschemes/Sica-iOS.xcscheme
+++ b/Sica.xcodeproj/xcshareddata/xcschemes/Sica-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0930"
+   LastUpgradeVersion = "1640"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -27,6 +27,15 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D4A60FE220ABC9890079871A"
+            BuildableName = "Sica.framework"
+            BlueprintName = "Sica-iOS"
+            ReferencedContainer = "container:Sica.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -39,17 +48,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "D4A60FE220ABC9890079871A"
-            BuildableName = "Sica.framework"
-            BlueprintName = "Sica-iOS"
-            ReferencedContainer = "container:Sica.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -70,8 +68,6 @@
             ReferencedContainer = "container:Sica.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Sica.xcodeproj/xcshareddata/xcschemes/Sica-macOS.xcscheme
+++ b/Sica.xcodeproj/xcshareddata/xcschemes/Sica-macOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0930"
+   LastUpgradeVersion = "1640"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -27,6 +27,15 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "9D436C3020E9E4DD00A1B938"
+            BuildableName = "Sica.framework"
+            BlueprintName = "Sica-macOS"
+            ReferencedContainer = "container:Sica.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -39,17 +48,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "9D436C3020E9E4DD00A1B938"
-            BuildableName = "Sica.framework"
-            BlueprintName = "Sica-macOS"
-            ReferencedContainer = "container:Sica.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -70,8 +68,6 @@
             ReferencedContainer = "container:Sica.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Sica.xcodeproj/xcshareddata/xcschemes/Sica-tvOS.xcscheme
+++ b/Sica.xcodeproj/xcshareddata/xcschemes/Sica-tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0930"
+   LastUpgradeVersion = "1640"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -27,6 +27,15 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "9D436C4220E9E71900A1B938"
+            BuildableName = "Sica.framework"
+            BlueprintName = "Sica-tvOS"
+            ReferencedContainer = "container:Sica.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -39,17 +48,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "9D436C4220E9E71900A1B938"
-            BuildableName = "Sica.framework"
-            BlueprintName = "Sica-tvOS"
-            ReferencedContainer = "container:Sica.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -70,8 +68,6 @@
             ReferencedContainer = "container:Sica.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Sica/Sica.h
+++ b/Sica/Sica.h
@@ -6,7 +6,7 @@
 //  Copyright © 2018年 中澤 郁斗. All rights reserved.
 //
 
-#import "TargetConditionals.h"
+#import <TargetConditionals.h>
 
 #if TARGET_OS_OSX
 #import <AppKit/AppKit.h>

--- a/Sica/Source/AnimationKeyPaths.swift
+++ b/Sica/Source/AnimationKeyPaths.swift
@@ -49,7 +49,7 @@ extension AnimationKeyPaths {
     public static let cornerRadius      = AnimationKeyPath<CGFloat>(keyPath: #keyPath(CALayer.cornerRadius))
     public static let filters           = AnimationKeyPath<[CIFilter]>(keyPath: #keyPath(CALayer.filters))
     public static let frame             = AnimationKeyPath<CGRect>(keyPath: #keyPath(CALayer.frame))
-    public static let hidden            = AnimationKeyPath<Bool>(keyPath: #keyPath(CALayer.hidden))
+    public static let hidden            = AnimationKeyPath<Bool>(keyPath: #keyPath(CALayer.isHidden))
     public static let mask              = AnimationKeyPath<CALayer>(keyPath: #keyPath(CALayer.mask))
     public static let masksToBounds     = AnimationKeyPath<Bool>(keyPath: #keyPath(CALayer.masksToBounds))
     public static let opacity           = AnimationKeyPath<CGFloat>(keyPath: #keyPath(CALayer.opacity))

--- a/Sica/Source/AnimationKeyPaths.swift
+++ b/Sica/Source/AnimationKeyPaths.swift
@@ -12,6 +12,7 @@ import UIKit
 import AppKit
 #endif
 
+@MainActor
 open class AnimationKeyPaths {
     fileprivate init() {}
 }

--- a/Sica/Source/Animator.swift
+++ b/Sica/Source/Animator.swift
@@ -14,6 +14,7 @@ import AppKit
 public typealias View = NSView
 #endif
 
+@MainActor
 public final class Animator {
 
     public enum AnimationPlayType {
@@ -35,7 +36,7 @@ public final class Animator {
     public let key: String
 
     #if DEBUG
-    private var _deinit: (() -> ())? = nil
+    nonisolated(unsafe) private var _deinit: (() -> ())? = nil
     deinit {
         _deinit?()
     }
@@ -173,6 +174,7 @@ public final class Animator {
 
 #if DEBUG
 extension Animator {
+    @MainActor
     struct Test {
         fileprivate let base: Animator
         

--- a/Sica/Source/Animator.swift
+++ b/Sica/Source/Animator.swift
@@ -24,6 +24,9 @@ public final class Animator {
         case parallel
     }
 
+    /// Flag whether or not to include the delay in the duration calculation when parallel.
+    public static var shouldIncludeDelayInParallelDuration: Bool = false
+
     private weak var layer: CALayer?
     private var group = CAAnimationGroup()
     private var animations = [CAAnimation]()
@@ -70,7 +73,11 @@ public final class Animator {
         case .sequence:
             return animations.last.map { $0.beginTime + $0.duration } ?? 0
         case .parallel:
-            return animations.map { $0.duration }.max() ?? 0
+            if Self.shouldIncludeDelayInParallelDuration {
+                return animations.map { $0.beginTime + $0.duration }.max() ?? 0
+            } else {
+                return animations.map { $0.duration }.max() ?? 0
+            }
         }
     }
 

--- a/Sica/Source/Animator.swift
+++ b/Sica/Source/Animator.swift
@@ -25,9 +25,6 @@ public final class Animator {
         case parallel
     }
 
-    /// Flag whether or not to include the delay in the duration calculation when parallel.
-    public static var shouldIncludeDelayInParallelDuration: Bool = false
-
     private weak var layer: CALayer?
     private var group = CAAnimationGroup()
     private var animations = [CAAnimation]()
@@ -74,11 +71,7 @@ public final class Animator {
         case .sequence:
             return animations.last.map { $0.beginTime + $0.duration } ?? 0
         case .parallel:
-            if Self.shouldIncludeDelayInParallelDuration {
-                return animations.map { $0.beginTime + $0.duration }.max() ?? 0
-            } else {
-                return animations.map { $0.duration }.max() ?? 0
-            }
+            return animations.map { $0.beginTime + $0.duration }.max() ?? 0
         }
     }
 

--- a/Sica/Source/CALayer+Sica.swift
+++ b/Sica/Source/CALayer+Sica.swift
@@ -9,9 +9,10 @@
 import Foundation
 import QuartzCore
 
-private let _animatorAssociatedKey = UnsafeMutablePointer<UInt>.allocate(capacity: 1)
+@MainActor private let _animatorAssociatedKey = UnsafeMutablePointer<UInt>.allocate(capacity: 1)
 
 extension CALayer {
+    @MainActor
     public var sica: Animator {
         set {
             objc_setAssociatedObject(self, _animatorAssociatedKey, newValue, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)

--- a/Sica/Source/FillMode.swift
+++ b/Sica/Source/FillMode.swift
@@ -9,7 +9,7 @@
 import Foundation
 import QuartzCore
 
-public struct FillMode {
+public struct FillMode: Sendable {
     typealias RawValue = CAMediaTimingFillMode
     public static let forwards = FillMode(rawValue: .forwards)
     public static let backwards = FillMode(rawValue: .backwards)

--- a/Sica/Source/FillMode.swift
+++ b/Sica/Source/FillMode.swift
@@ -10,19 +10,11 @@ import Foundation
 import QuartzCore
 
 public struct FillMode {
-    #if swift(>=4.2)
     typealias RawValue = CAMediaTimingFillMode
     public static let forwards = FillMode(rawValue: .forwards)
     public static let backwards = FillMode(rawValue: .backwards)
     public static let both = FillMode(rawValue: .both)
     public static let removed = FillMode(rawValue: .removed)
-    #else
-    typealias RawValue = String
-    public static let forwards = FillMode(rawValue: kCAFillModeForwards)
-    public static let backwards = FillMode(rawValue: kCAFillModeBackwards)
-    public static let both = FillMode(rawValue: kCAFillModeBoth)
-    public static let removed = FillMode(rawValue: kCAFillModeRemoved)
-    #endif
 
     let rawValue: RawValue
 }

--- a/Sica/Source/TimingFunction.swift
+++ b/Sica/Source/TimingFunction.swift
@@ -9,22 +9,12 @@
 import QuartzCore
 
 public struct TimingFunction {
-    #if swift(>=4.2)
     public typealias NameValue = CAMediaTimingFunctionName
     public static let `default` = TimingFunction(name: CAMediaTimingFunctionName.default)
     public static let linear = TimingFunction(name: CAMediaTimingFunctionName.linear)
     public static let easeIn = TimingFunction(name: CAMediaTimingFunctionName.easeIn)
     public static let easeOut = TimingFunction(name: CAMediaTimingFunctionName.easeOut)
     public static let easeInEaseOut = TimingFunction(name: CAMediaTimingFunctionName.easeInEaseOut)
-    #else
-    public typealias NameValue = String
-    public static let `default` = TimingFunction(name: kCAMediaTimingFunctionDefault)
-    public static let linear = TimingFunction(name: kCAMediaTimingFunctionLinear)
-    public static let easeIn = TimingFunction(name: kCAMediaTimingFunctionEaseIn)
-    public static let easeOut = TimingFunction(name: kCAMediaTimingFunctionEaseOut)
-    public static let easeInEaseOut = TimingFunction(name: kCAMediaTimingFunctionEaseInEaseOut)
-    #endif
-    
     
     public let name: NameValue
     public let rawValue: CAMediaTimingFunction

--- a/Sica/Source/TimingFunction.swift
+++ b/Sica/Source/TimingFunction.swift
@@ -8,7 +8,7 @@
 
 import QuartzCore
 
-public struct TimingFunction {
+public struct TimingFunction: @unchecked Sendable {
     public typealias NameValue = CAMediaTimingFunctionName
     public static let `default` = TimingFunction(name: CAMediaTimingFunctionName.default)
     public static let linear = TimingFunction(name: CAMediaTimingFunctionName.linear)

--- a/Sica/Source/Transition.swift
+++ b/Sica/Source/Transition.swift
@@ -8,7 +8,7 @@
 
 import QuartzCore
 
-public struct Transition {
+public struct Transition: Sendable {
     typealias RawValue = CATransitionType
     public static let fade = Transition(rawValue: .fade)
     public static let moveIn = Transition(rawValue: .moveIn)
@@ -18,7 +18,7 @@ public struct Transition {
     let rawValue: RawValue
 }
 
-public struct TransitionSub {
+public struct TransitionSub: Sendable {
     typealias RawValue = CATransitionSubtype
     public static let right = TransitionSub(rawValue: .fromRight)
     public static let left = TransitionSub(rawValue: .fromLeft)

--- a/Sica/Source/Transition.swift
+++ b/Sica/Source/Transition.swift
@@ -9,37 +9,21 @@
 import QuartzCore
 
 public struct Transition {
-    #if swift(>=4.2)
     typealias RawValue = CATransitionType
     public static let fade = Transition(rawValue: .fade)
     public static let moveIn = Transition(rawValue: .moveIn)
     public static let push = Transition(rawValue: .push)
     public static let reveal = Transition(rawValue: .reveal)
-    #else
-    typealias RawValue = String
-    public static let fade = Transition(rawValue: kCATransitionFade)
-    public static let moveIn = Transition(rawValue: kCATransitionMoveIn)
-    public static let push = Transition(rawValue: kCATransitionPush)
-    public static let reveal = Transition(rawValue: kCATransitionReveal)
-    #endif
 
     let rawValue: RawValue
 }
 
 public struct TransitionSub {
-    #if swift(>=4.2)
     typealias RawValue = CATransitionSubtype
     public static let right = TransitionSub(rawValue: .fromRight)
     public static let left = TransitionSub(rawValue: .fromLeft)
     public static let top = TransitionSub(rawValue: .fromTop)
     public static let bottom = TransitionSub(rawValue: .fromBottom)
-    #else
-    typealias RawValue = String
-    public static let right = TransitionSub(rawValue: kCATransitionFromRight)
-    public static let left = TransitionSub(rawValue: kCATransitionFromLeft)
-    public static let top = TransitionSub(rawValue: kCATransitionFromTop)
-    public static let bottom = TransitionSub(rawValue: kCATransitionFromBottom)
-    #endif
 
     let rawValue: RawValue
 }

--- a/Sica/Source/View+Sica.swift
+++ b/Sica/Source/View+Sica.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-private let _animatorAssociatedKey = UnsafeMutablePointer<UInt>.allocate(capacity: 1)
+@MainActor private let _animatorAssociatedKey = UnsafeMutablePointer<UInt>.allocate(capacity: 1)
 
 extension View {
     public var sica: Animator {

--- a/SicaTests/SicaTests.swift
+++ b/SicaTests/SicaTests.swift
@@ -9,11 +9,12 @@
 import XCTest
 @testable import Sica
 
-class SicaTests: XCTestCase {
+@MainActor
+class SicaTests: XCTestCase, Sendable {
     var animator = Animator(view: View())
     
-    override func setUp() {
-        super.setUp()
+    override func setUp() async throws {
+        try await super.setUp()
         animator = Animator(view: View())
     }
     


### PR DESCRIPTION
- Swift6 モードに切り替え
- iOS Deployment Target を 16.0 に変更
- 上記変更に伴う修正
- `shouldIncludeDelayInParallelDuration` flagを削除し `true` に設定したときの挙動に統一